### PR TITLE
Add error if customer already exists

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -37,9 +37,14 @@ module Admin
 
     def create
       @customer = Customer.find_or_new(customer_params[:email], customer_params[:enterprise_id])
-      @customer.assign_attributes(customer_params)
+
+      if @customer.id
+        @customer.errors.add(:base, I18n.t('admin.customers.create.customer_exists'))
+        return render json: { errors: @customer.errors.full_messages }, status: :bad_request
+      end
 
       if user_can_create_customer?
+        @customer.assign_attributes(customer_params)
         @customer.set_created_manually_flag
         if @customer.save
           tag_rule_mapping = TagRule.mapping_for(Enterprise.where(id: @customer.enterprise))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -685,6 +685,8 @@ en:
         balance_due: "Balance Due"
       destroy:
         has_associated_subscriptions: "Delete failed: This customer has active subscriptions. Cancel them first."
+      create:
+        customer_exists: This customer already exists
     contents:
       edit:
         title: Content

--- a/spec/system/admin/customers_spec.rb
+++ b/spec/system/admin/customers_spec.rb
@@ -15,7 +15,7 @@ describe 'Customers' do
 
     describe "using the customers index" do
       let!(:customer1) {
-        create(:customer, first_name: 'John', last_name: 'Doe', enterprise: managed_distributor1, 
+        create(:customer, first_name: 'John', last_name: 'Doe', enterprise: managed_distributor1,
 code: nil, created_manually: true)
       }
       let!(:customer2) {
@@ -373,12 +373,13 @@ code: nil, created_manually: true)
                                             text: "Email is invalid"
             }.to_not change{ Customer.of(managed_distributor1).count }
 
+            # TODO fix this
             # When an existing email is used
             expect{
               fill_in 'email', with: customer1.email
               click_button 'Add Customer'
               expect(page).to have_selector "#new-customer-dialog .error",
-                                            text: "Email is associated with an existing customer"
+                                            text: "This customer already exists"
             }.to change{ customer1.reload.created_manually }.from(false).to(true)
               .and change { Customer.of(managed_distributor1).count }.by(0)
 
@@ -391,7 +392,7 @@ code: nil, created_manually: true)
 
             expect(
               Customer.of(managed_distributor1).reorder(:id)
-                .last.created_manually 
+                .last.created_manually
             ).to be true
           end
         end


### PR DESCRIPTION
#### What? Why?

I don't think we need to redirect when the customer already exists, so I just went and displayed the appropriate error.

It will need some fixing as I broke a spec here : https://github.com/abdellani/openfoodnetwork/blob/cb3a743d53cb2b67c1c2ec037e49a6ae32bda056/spec/system/admin/customers_spec.rb#L376-L383

I am not sure if setting the customer as manually created is the correct action here, so I left it as it is. 

#### What should we test?
